### PR TITLE
Groovy syntax support for trait, record and var

### DIFF
--- a/extensions/groovy/syntaxes/groovy.tmLanguage.json
+++ b/extensions/groovy/syntaxes/groovy.tmLanguage.json
@@ -258,7 +258,7 @@
 			]
 		},
 		"class": {
-			"begin": "(?=\\w?[\\w\\s]*(?:class|(?:@)?interface|enum)\\s+\\w+)",
+			"begin": "(?=\\w?[\\w\\s]*(?:class|(?:@)?interface|enum|trait|record)\\s+\\w+)",
 			"end": "}",
 			"endCaptures": {
 				"0": {
@@ -1284,7 +1284,7 @@
 		"types": {
 			"patterns": [
 				{
-					"match": "\\b(def)\\b",
+					"match": "\\b(def|var)\\b",
 					"name": "storage.type.def.groovy"
 				},
 				{


### PR DESCRIPTION
Groovy added support for traits (introduced in v2.3) and records (in v4), and the var keyword as an alternative to def for defining variables (in v4)

Fixes #189638

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

